### PR TITLE
Target JMC 7.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>com.redhat.rhjmc</groupId>
 <artifactId>containerjfr-core</artifactId>
-<version>0.10.0</version>
+<version>0.11.0</version>
 <packaging>jar</packaging>
 <name>containerjfr-core</name>
 <url>http://maven.apache.org</url>
@@ -15,7 +15,7 @@
   <java.version>11</java.version>
   <maven.compiler.target>${java.version}</maven.compiler.target>
   <maven.compiler.source>${java.version}</maven.compiler.source>
-  <jmc.version>8.0.0-SNAPSHOT</jmc.version>
+  <jmc.version>7.1.1-SNAPSHOT</jmc.version>
 
   <org.apache.maven.plugins.compiler.version>3.6.1</org.apache.maven.plugins.compiler.version>
   <org.apache.maven.plugins.surefire.version>3.0.0-M4</org.apache.maven.plugins.surefire.version>
@@ -56,7 +56,7 @@
   </dependency>
   <dependency>
     <groupId>org.openjdk.jmc</groupId>
-    <artifactId>jdp</artifactId>
+    <artifactId>org.openjdk.jmc.jdp</artifactId>
     <version>${jmc.version}</version>
   </dependency>
   <dependency>


### PR DESCRIPTION
This sets the targeted upstream JMC version to 7.1.1, the latest in the 7 release series, rather than a rolling 8 development snapshot.

The JMC `jdp` artifactId has been put back to where it is located in JMC7. It had previously been updated for the changed location that will be present in JMC8.