### PR TITLE
Local, Mutable Templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 
   <org.apache.commons.lang3.version>3.9</org.apache.commons.lang3.version>
   <org.apache.commons.io.version>2.6</org.apache.commons.io.version>
+  <org.apache.commons.text.version>1.8</org.apache.commons.text.version>
   <org.jsoup.version>1.12.1</org.jsoup.version>
 
   <com.github.spotbugs.version>4.0.0-RC1</com.github.spotbugs.version>
@@ -130,6 +131,12 @@
     <groupId>commons-io</groupId>
     <artifactId>commons-io</artifactId>
     <version>${org.apache.commons.io.version}</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-text</artifactId>
+    <version>${org.apache.commons.text.version}</version>
     <scope>test</scope>
   </dependency>
 </dependencies>

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkit.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkit.java
@@ -47,14 +47,20 @@ import javax.management.remote.JMXServiceURL;
 
 import org.openjdk.jmc.rjmx.ConnectionDescriptorBuilder;
 
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 
 public class JFRConnectionToolkit {
 
     private final ClientWriter cw;
+    private final FileSystem fs;
+    private final Environment env;
 
-    public JFRConnectionToolkit(ClientWriter cw) {
+    public JFRConnectionToolkit(ClientWriter cw, FileSystem fs, Environment env) {
         this.cw = cw;
+        this.fs = fs;
+        this.env = env;
     }
 
     public JFRConnection connect(JMXServiceURL url) throws Exception {
@@ -62,7 +68,8 @@ public class JFRConnectionToolkit {
     }
 
     public JFRConnection connect(JMXServiceURL url, List<Runnable> listeners) throws Exception {
-        return new JFRConnection(cw, new ConnectionDescriptorBuilder().url(url).build(), listeners);
+        return new JFRConnection(
+                cw, fs, env, new ConnectionDescriptorBuilder().url(url).build(), listeners);
     }
 
     public JFRConnection connect(String host) throws Exception {
@@ -71,7 +78,11 @@ public class JFRConnectionToolkit {
 
     public JFRConnection connect(String host, int port, List<Runnable> listeners) throws Exception {
         return new JFRConnection(
-                cw, new ConnectionDescriptorBuilder().hostName(host).port(port).build(), listeners);
+                cw,
+                fs,
+                env,
+                new ConnectionDescriptorBuilder().hostName(host).port(port).build(),
+                listeners);
     }
 
     public JFRConnection connect(String host, int port) throws Exception {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/sys/FileSystem.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/sys/FileSystem.java
@@ -66,12 +66,29 @@ public class FileSystem {
         return Files.isReadable(path);
     }
 
+    public boolean isWritable(Path path) {
+        return Files.isWritable(path);
+    }
+
+    public boolean isExecutable(Path path) {
+        return Files.isExecutable(path);
+    }
+
     public InputStream newInputStream(Path path, OpenOption... openOptions) throws IOException {
         return Files.newInputStream(path, openOptions);
     }
 
+    public Path writeString(Path path, CharSequence content, OpenOption... openOptions)
+            throws IOException {
+        return Files.writeString(path, content, openOptions);
+    }
+
     public BufferedReader readFile(Path path) throws IOException {
         return Files.newBufferedReader(path);
+    }
+
+    public String readString(Path path) throws IOException {
+        return Files.readString(path);
     }
 
     public long copy(InputStream in, Path out, CopyOption... copyOptions) throws IOException {
@@ -92,5 +109,9 @@ public class FileSystem {
 
     public Path pathOf(String first, String... more) {
         return Path.of(first, more);
+    }
+
+    public long size(Path path) throws IOException {
+        return Files.size(path);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/AbstractTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/AbstractTemplateService.java
@@ -42,27 +42,40 @@
 package com.redhat.rhjmc.containerjfr.core.templates;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
-import org.jsoup.nodes.Document;
-
-import org.openjdk.jmc.common.unit.IConstrainedMap;
-import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
+import org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration.model.xml.XMLModel;
+import org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration.model.xml.XMLTagInstance;
 
 import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
 
-public interface TemplateService {
+abstract class AbstractTemplateService implements TemplateService {
 
-    List<Template> getTemplates() throws FlightRecorderException;
-
-    Document getXml(String templateName) throws FlightRecorderException;
-
-    IConstrainedMap<EventOptionID> getEventsByTemplateName(String templateName)
-            throws FlightRecorderException;
-
-    @SuppressWarnings("serial")
-    public static class UnknownEventTemplateException extends RuntimeException {
-        public UnknownEventTemplateException(String templateName) {
-            super(String.format("Unknown event template \"%s\"", templateName));
+    @Override
+    public List<Template> getTemplates() throws FlightRecorderException {
+        try {
+            return getTemplateModels().stream()
+                    .map(xml -> xml.getRoot())
+                    .map(
+                            root ->
+                                    new Template(
+                                            getAttributeValue(root, "label"),
+                                            getAttributeValue(root, "description"),
+                                            getAttributeValue(root, "provider")))
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new FlightRecorderException(e);
         }
+    }
+
+    protected abstract List<XMLModel> getTemplateModels() throws FlightRecorderException;
+
+    protected String getAttributeValue(XMLTagInstance node, String valueKey) {
+        return node.getAttributeInstances().stream()
+                .filter(i -> Objects.equals(valueKey, i.getAttribute().getName()))
+                .map(i -> i.getValue())
+                .findFirst()
+                .get();
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateService.java
@@ -163,7 +163,11 @@ public class LocalStorageTemplateService extends AbstractTemplateService
     }
 
     @Override
-    public Optional<Document> getXml(String templateName) throws FlightRecorderException {
+    public Optional<Document> getXml(String templateName, TemplateType type)
+            throws FlightRecorderException {
+        if (!providedTemplateType().equals(type)) {
+            return Optional.empty();
+        }
         for (Path path : getLocalTemplates()) {
             try (InputStream stream = fs.newInputStream(path)) {
                 Document doc =
@@ -193,8 +197,11 @@ public class LocalStorageTemplateService extends AbstractTemplateService
     }
 
     @Override
-    public Optional<IConstrainedMap<EventOptionID>> getEventsByTemplateName(String templateName)
-            throws FlightRecorderException {
+    public Optional<IConstrainedMap<EventOptionID>> getEvents(
+            String templateName, TemplateType type) throws FlightRecorderException {
+        if (!providedTemplateType().equals(type)) {
+            return Optional.empty();
+        }
         return getTemplateModels().stream()
                 .filter(
                         m ->

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateService.java
@@ -83,6 +83,11 @@ public class LocalStorageTemplateService extends AbstractTemplateService
     }
 
     @Override
+    protected TemplateType providedTemplateType() {
+        return TemplateType.CUSTOM;
+    }
+
+    @Override
     public void addTemplate(InputStream templateStream)
             throws InvalidXmlException, InvalidEventTemplateException, IOException {
         if (!env.hasEnv(TEMPLATE_PATH)) {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateService.java
@@ -129,9 +129,21 @@ public class LocalStorageTemplateService extends AbstractTemplateService
     }
 
     @Override
-    public void deleteTemplate(String templateName) throws UnknownEventTemplateException {
-        // TODO
-        throw new UnsupportedOperationException();
+    public void deleteTemplate(String templateName) throws IOException {
+        if (!env.hasEnv(TEMPLATE_PATH)) {
+            throw new IOException(
+                    String.format(
+                            "Template directory does not exist, must be set using environment variable %s",
+                            TEMPLATE_PATH));
+        }
+        Path dir = fs.pathOf(env.getEnv(TEMPLATE_PATH));
+        if (!fs.exists(dir) || !fs.isDirectory(dir) || !fs.isReadable(dir) || !fs.isWritable(dir)) {
+            throw new IOException(
+                    String.format(
+                            "Template directory %s does not exist, is not a directory, or does not have appropriate permissions",
+                            dir.toString()));
+        }
+        fs.deleteIfExists(fs.pathOf(env.getEnv(TEMPLATE_PATH), templateName));
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MalformedXMLException.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MalformedXMLException.java
@@ -41,28 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.core.templates;
 
-import java.util.List;
-
-import org.jsoup.nodes.Document;
-
-import org.openjdk.jmc.common.unit.IConstrainedMap;
-import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
-
-import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
-
-public interface TemplateService {
-
-    List<Template> getTemplates() throws FlightRecorderException;
-
-    Document getXml(String templateName) throws FlightRecorderException;
-
-    IConstrainedMap<EventOptionID> getEventsByTemplateName(String templateName)
-            throws FlightRecorderException;
-
-    @SuppressWarnings("serial")
-    public static class UnknownEventTemplateException extends Exception {
-        public UnknownEventTemplateException(String templateName) {
-            super(String.format("Unknown event template \"%s\"", templateName));
-        }
+public class MalformedXMLException extends RuntimeException {
+    MalformedXMLException(String reason) {
+        super(reason);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
@@ -109,7 +109,8 @@ public class MergedTemplateService implements MutableTemplateService {
     }
 
     @Override
-    public void deleteTemplate(String templateName) throws IOException {
+    public void deleteTemplate(String templateName)
+            throws IOException, InvalidEventTemplateException {
         local.deleteTemplate(templateName);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
@@ -76,30 +76,29 @@ public class MergedTemplateService implements MutableTemplateService {
     }
 
     @Override
-    public Optional<Document> getXml(String templateName) throws FlightRecorderException {
-        return local.getXml(templateName)
-                .or(
-                        () -> {
-                            try {
-                                return remote.getXml(templateName);
-                            } catch (FlightRecorderException e) {
-                                return Optional.empty();
-                            }
-                        });
+    public Optional<Document> getXml(String templateName, TemplateType type)
+            throws FlightRecorderException {
+        switch (type) {
+            case CUSTOM:
+                return local.getXml(templateName, type);
+            case TARGET:
+                return remote.getXml(templateName, type);
+            default:
+                return Optional.empty();
+        }
     }
 
     @Override
-    public Optional<IConstrainedMap<EventOptionID>> getEventsByTemplateName(String templateName)
-            throws FlightRecorderException {
-        return local.getEventsByTemplateName(templateName)
-                .or(
-                        () -> {
-                            try {
-                                return remote.getEventsByTemplateName(templateName);
-                            } catch (FlightRecorderException e) {
-                                return Optional.empty();
-                            }
-                        });
+    public Optional<IConstrainedMap<EventOptionID>> getEvents(
+            String templateName, TemplateType type) throws FlightRecorderException {
+        switch (type) {
+            case CUSTOM:
+                return local.getEvents(templateName, type);
+            case TARGET:
+                return remote.getEvents(templateName, type);
+            default:
+                return Optional.empty();
+        }
     }
 
     @Override

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
@@ -111,7 +111,7 @@ public class MergedTemplateService implements MutableTemplateService {
     }
 
     @Override
-    public void deleteTemplate(String templateName) throws UnknownEventTemplateException {
+    public void deleteTemplate(String templateName) throws IOException {
         local.deleteTemplate(templateName);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
@@ -41,6 +41,7 @@
  */
 package com.redhat.rhjmc.containerjfr.core.templates;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -105,7 +106,7 @@ public class MergedTemplateService implements MutableTemplateService {
 
     @Override
     public void addTemplate(InputStream templateStream)
-            throws InvalidXmlException, InvalidEventTemplateException {
+            throws InvalidXmlException, InvalidEventTemplateException, IOException {
         local.addTemplate(templateStream);
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
@@ -1,0 +1,116 @@
+/*-
+ * #%L
+ * Container JFR Core
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.core.templates;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.jsoup.nodes.Document;
+
+import org.openjdk.jmc.common.unit.IConstrainedMap;
+import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
+
+import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
+import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+
+public class MergedTemplateService implements MutableTemplateService {
+
+    protected final RemoteTemplateService remote;
+    protected final LocalStorageTemplateService local;
+
+    public MergedTemplateService(JFRConnection conn, FileSystem fs, Environment env) {
+        this.remote = new RemoteTemplateService(conn);
+        this.local = new LocalStorageTemplateService(fs, env);
+    }
+
+    @Override
+    public List<Template> getTemplates() throws FlightRecorderException {
+        List<Template> templates = new ArrayList<>();
+        templates.addAll(remote.getTemplates());
+        templates.addAll(local.getTemplates());
+        return templates;
+    }
+
+    @Override
+    public Optional<Document> getXml(String templateName) throws FlightRecorderException {
+        // FIXME what if the remote has a template by the same name as something local? We should
+        // add some way to distinguish them and separate them into namespaces of sorts
+        return local.getXml(templateName)
+                .or(
+                        () -> {
+                            try {
+                                return remote.getXml(templateName);
+                            } catch (FlightRecorderException e) {
+                                return Optional.empty();
+                            }
+                        });
+    }
+
+    @Override
+    public Optional<IConstrainedMap<EventOptionID>> getEventsByTemplateName(String templateName)
+            throws FlightRecorderException {
+        return local.getEventsByTemplateName(templateName)
+                .or(
+                        () -> {
+                            try {
+                                return remote.getEventsByTemplateName(templateName);
+                            } catch (FlightRecorderException e) {
+                                return Optional.empty();
+                            }
+                        });
+    }
+
+    @Override
+    public void addTemplate(InputStream templateStream)
+            throws InvalidXmlException, InvalidEventTemplateException {
+        local.addTemplate(templateStream);
+    }
+
+    @Override
+    public void deleteTemplate(String templateName) throws UnknownEventTemplateException {
+        local.deleteTemplate(templateName);
+    }
+}

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
@@ -77,8 +77,6 @@ public class MergedTemplateService implements MutableTemplateService {
 
     @Override
     public Optional<Document> getXml(String templateName) throws FlightRecorderException {
-        // FIXME what if the remote has a template by the same name as something local? We should
-        // add some way to distinguish them and separate them into namespaces of sorts
         return local.getXml(templateName)
                 .or(
                         () -> {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MutableTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MutableTemplateService.java
@@ -41,28 +41,26 @@
  */
 package com.redhat.rhjmc.containerjfr.core.templates;
 
-import java.util.List;
+import java.io.InputStream;
 
-import org.jsoup.nodes.Document;
+public interface MutableTemplateService extends TemplateService {
 
-import org.openjdk.jmc.common.unit.IConstrainedMap;
-import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
+    void addTemplate(InputStream templateStream)
+            throws InvalidXmlException, InvalidEventTemplateException;
 
-import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
-
-public interface TemplateService {
-
-    List<Template> getTemplates() throws FlightRecorderException;
-
-    Document getXml(String templateName) throws FlightRecorderException;
-
-    IConstrainedMap<EventOptionID> getEventsByTemplateName(String templateName)
-            throws FlightRecorderException;
+    void deleteTemplate(String templateName) throws UnknownEventTemplateException;
 
     @SuppressWarnings("serial")
-    public static class UnknownEventTemplateException extends RuntimeException {
-        public UnknownEventTemplateException(String templateName) {
-            super(String.format("Unknown event template \"%s\"", templateName));
+    public static class InvalidXmlException extends Exception {
+        InvalidXmlException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    @SuppressWarnings("serial")
+    public static class InvalidEventTemplateException extends Exception {
+        InvalidEventTemplateException(String message, Throwable cause) {
+            super(message, cause);
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MutableTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MutableTemplateService.java
@@ -49,7 +49,7 @@ public interface MutableTemplateService extends TemplateService {
     void addTemplate(InputStream templateStream)
             throws InvalidXmlException, InvalidEventTemplateException, IOException;
 
-    void deleteTemplate(String templateName) throws UnknownEventTemplateException;
+    void deleteTemplate(String templateName) throws IOException;
 
     @SuppressWarnings("serial")
     public static class InvalidXmlException extends Exception {

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MutableTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MutableTemplateService.java
@@ -49,7 +49,7 @@ public interface MutableTemplateService extends TemplateService {
     void addTemplate(InputStream templateStream)
             throws InvalidXmlException, InvalidEventTemplateException, IOException;
 
-    void deleteTemplate(String templateName) throws IOException;
+    void deleteTemplate(String templateName) throws IOException, InvalidEventTemplateException;
 
     @SuppressWarnings("serial")
     public static class InvalidXmlException extends Exception {
@@ -66,6 +66,10 @@ public interface MutableTemplateService extends TemplateService {
     public static class InvalidEventTemplateException extends Exception {
         InvalidEventTemplateException(String message, Throwable cause) {
             super(message, cause);
+        }
+
+        InvalidEventTemplateException(String message) {
+            super(message);
         }
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MutableTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MutableTemplateService.java
@@ -41,12 +41,13 @@
  */
 package com.redhat.rhjmc.containerjfr.core.templates;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 public interface MutableTemplateService extends TemplateService {
 
     void addTemplate(InputStream templateStream)
-            throws InvalidXmlException, InvalidEventTemplateException;
+            throws InvalidXmlException, InvalidEventTemplateException, IOException;
 
     void deleteTemplate(String templateName) throws UnknownEventTemplateException;
 
@@ -54,6 +55,10 @@ public interface MutableTemplateService extends TemplateService {
     public static class InvalidXmlException extends Exception {
         InvalidXmlException(String message, Throwable cause) {
             super(message, cause);
+        }
+
+        InvalidXmlException(String message) {
+            super(message);
         }
     }
 

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/RemoteTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/RemoteTemplateService.java
@@ -72,6 +72,11 @@ public class RemoteTemplateService extends AbstractTemplateService implements Te
     }
 
     @Override
+    protected TemplateType providedTemplateType() {
+        return TemplateType.TARGET;
+    }
+
+    @Override
     public Optional<Document> getXml(String templateName) throws FlightRecorderException {
         try {
             return conn.getService().getServerTemplates().stream()

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/RemoteTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/RemoteTemplateService.java
@@ -77,7 +77,11 @@ public class RemoteTemplateService extends AbstractTemplateService implements Te
     }
 
     @Override
-    public Optional<Document> getXml(String templateName) throws FlightRecorderException {
+    public Optional<Document> getXml(String templateName, TemplateType type)
+            throws FlightRecorderException {
+        if (!providedTemplateType().equals(type)) {
+            return Optional.empty();
+        }
         try {
             return conn.getService().getServerTemplates().stream()
                     .map(xmlText -> Jsoup.parse(xmlText, "", Parser.xmlParser()))
@@ -106,8 +110,11 @@ public class RemoteTemplateService extends AbstractTemplateService implements Te
     }
 
     @Override
-    public Optional<IConstrainedMap<EventOptionID>> getEventsByTemplateName(String templateName)
-            throws FlightRecorderException {
+    public Optional<IConstrainedMap<EventOptionID>> getEvents(
+            String templateName, TemplateType type) throws FlightRecorderException {
+        if (!providedTemplateType().equals(type)) {
+            return Optional.empty();
+        }
         return getTemplateModels().stream()
                 .filter(
                         m ->

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/Template.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/Template.java
@@ -50,11 +50,13 @@ public class Template {
     private final String name;
     private final String description;
     private final String provider;
+    private final TemplateType type;
 
-    public Template(String name, String description, String provider) {
+    public Template(String name, String description, String provider, TemplateType type) {
         this.name = name;
         this.description = description;
         this.provider = provider;
+        this.type = type;
     }
 
     public String getName() {
@@ -69,12 +71,17 @@ public class Template {
         return provider;
     }
 
+    public TemplateType getType() {
+        return type;
+    }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .append("name", name)
                 .append("description", description)
                 .append("provider", provider)
+                .append("type", type)
                 .toString();
     }
 
@@ -92,11 +99,12 @@ public class Template {
         Template other = (Template) o;
         return Objects.equals(getName(), other.getName())
                 && Objects.equals(getDescription(), other.getDescription())
-                && Objects.equals(getProvider(), other.getProvider());
+                && Objects.equals(getProvider(), other.getProvider())
+                && Objects.equals(getType(), other.getType());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, provider);
+        return Objects.hash(name, description, provider, type);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/TemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/TemplateService.java
@@ -59,11 +59,4 @@ public interface TemplateService {
 
     Optional<IConstrainedMap<EventOptionID>> getEventsByTemplateName(String templateName)
             throws FlightRecorderException;
-
-    @SuppressWarnings("serial")
-    public static class UnknownEventTemplateException extends RuntimeException {
-        public UnknownEventTemplateException(String templateName) {
-            super(String.format("Unknown event template \"%s\"", templateName));
-        }
-    }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/TemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/TemplateService.java
@@ -42,6 +42,7 @@
 package com.redhat.rhjmc.containerjfr.core.templates;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.jsoup.nodes.Document;
 
@@ -54,9 +55,9 @@ public interface TemplateService {
 
     List<Template> getTemplates() throws FlightRecorderException;
 
-    Document getXml(String templateName) throws FlightRecorderException;
+    Optional<Document> getXml(String templateName) throws FlightRecorderException;
 
-    IConstrainedMap<EventOptionID> getEventsByTemplateName(String templateName)
+    Optional<IConstrainedMap<EventOptionID>> getEventsByTemplateName(String templateName)
             throws FlightRecorderException;
 
     @SuppressWarnings("serial")

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/TemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/TemplateService.java
@@ -55,8 +55,9 @@ public interface TemplateService {
 
     List<Template> getTemplates() throws FlightRecorderException;
 
-    Optional<Document> getXml(String templateName) throws FlightRecorderException;
+    Optional<Document> getXml(String templateName, TemplateType type)
+            throws FlightRecorderException;
 
-    Optional<IConstrainedMap<EventOptionID>> getEventsByTemplateName(String templateName)
+    Optional<IConstrainedMap<EventOptionID>> getEvents(String templateName, TemplateType type)
             throws FlightRecorderException;
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/TemplateType.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/TemplateType.java
@@ -41,44 +41,8 @@
  */
 package com.redhat.rhjmc.containerjfr.core.templates;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration.model.xml.XMLModel;
-import org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration.model.xml.XMLTagInstance;
-
-import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
-
-abstract class AbstractTemplateService implements TemplateService {
-
-    @Override
-    public List<Template> getTemplates() throws FlightRecorderException {
-        try {
-            return getTemplateModels().stream()
-                    .map(xml -> xml.getRoot())
-                    .map(
-                            root ->
-                                    new Template(
-                                            getAttributeValue(root, "label"),
-                                            getAttributeValue(root, "description"),
-                                            getAttributeValue(root, "provider"),
-                                            providedTemplateType()))
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new FlightRecorderException(e);
-        }
-    }
-
-    protected abstract TemplateType providedTemplateType();
-
-    protected abstract List<XMLModel> getTemplateModels() throws FlightRecorderException;
-
-    protected String getAttributeValue(XMLTagInstance node, String valueKey) {
-        return node.getAttributeInstances().stream()
-                .filter(i -> Objects.equals(valueKey, i.getAttribute().getName()))
-                .map(i -> i.getValue())
-                .findFirst()
-                .get();
-    }
+public enum TemplateType {
+    TARGET,
+    CUSTOM,
+    ;
 }

--- a/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/ControlPanel.java
+++ b/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/ControlPanel.java
@@ -39,30 +39,20 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr.core.templates;
+package org.openjdk.jmc.flightrecorder.controlpanel.ui;
 
-import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-import org.jsoup.nodes.Document;
+public class ControlPanel {
 
-import org.openjdk.jmc.common.unit.IConstrainedMap;
-import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
+    public static ControlPanel getDefault() {
+        return new ControlPanel();
+    }
 
-import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
-
-public interface TemplateService {
-
-    List<Template> getTemplates() throws FlightRecorderException;
-
-    Document getXml(String templateName) throws FlightRecorderException;
-
-    IConstrainedMap<EventOptionID> getEventsByTemplateName(String templateName)
-            throws FlightRecorderException;
-
-    @SuppressWarnings("serial")
-    public static class UnknownEventTemplateException extends RuntimeException {
-        public UnknownEventTemplateException(String templateName) {
-            super(String.format("Unknown event template \"%s\"", templateName));
-        }
+    public Logger getLogger() {
+        Logger logger = Logger.getGlobal();
+        logger.setLevel(Level.ALL);
+        return logger;
     }
 }

--- a/src/main/java/org/openjdk/jmc/ui/MCAbstractUIPlugin.java
+++ b/src/main/java/org/openjdk/jmc/ui/MCAbstractUIPlugin.java
@@ -39,30 +39,6 @@
  * SOFTWARE.
  * #L%
  */
-package com.redhat.rhjmc.containerjfr.core.templates;
+package org.openjdk.jmc.ui;
 
-import java.util.List;
-
-import org.jsoup.nodes.Document;
-
-import org.openjdk.jmc.common.unit.IConstrainedMap;
-import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
-
-import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
-
-public interface TemplateService {
-
-    List<Template> getTemplates() throws FlightRecorderException;
-
-    Document getXml(String templateName) throws FlightRecorderException;
-
-    IConstrainedMap<EventOptionID> getEventsByTemplateName(String templateName)
-            throws FlightRecorderException;
-
-    @SuppressWarnings("serial")
-    public static class UnknownEventTemplateException extends RuntimeException {
-        public UnknownEventTemplateException(String templateName) {
-            super(String.format("Unknown event template \"%s\"", templateName));
-        }
-    }
-}
+public class MCAbstractUIPlugin {}

--- a/src/main/java/org/openjdk/jmc/ui/UIPlugin.java
+++ b/src/main/java/org/openjdk/jmc/ui/UIPlugin.java
@@ -41,6 +41,7 @@
  */
 package org.openjdk.jmc.ui;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -54,6 +55,8 @@ public class UIPlugin {
     }
 
     public Logger getLogger() {
-        return Logger.getGlobal();
+        Logger logger = Logger.getGlobal();
+        logger.setLevel(Level.ALL);
+        return logger;
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkitTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkitTest.java
@@ -51,6 +51,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.openjdk.jmc.rjmx.internal.WrappedConnectionException;
 
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
 import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
 
 @ExtendWith(MockitoExtension.class)
@@ -58,10 +60,12 @@ class JFRConnectionToolkitTest {
 
     JFRConnectionToolkit toolkit;
     @Mock ClientWriter cw;
+    @Mock FileSystem fs;
+    @Mock Environment env;
 
     @BeforeEach
     void setup() {
-        toolkit = new JFRConnectionToolkit(cw);
+        toolkit = new JFRConnectionToolkit(cw, fs, env);
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
@@ -112,7 +112,7 @@ class LocalStorageTemplateServiceTest {
     }
 
     @Test
-    void getEventsByNameShouldReturnNonEmptyMap() throws Exception {
+    void getEventsShouldReturnNonEmptyMap() throws Exception {
         Mockito.when(env.hasEnv(LocalStorageTemplateService.TEMPLATE_PATH)).thenReturn(true);
         Mockito.when(env.getEnv(LocalStorageTemplateService.TEMPLATE_PATH))
                 .thenReturn("/templates");
@@ -132,13 +132,18 @@ class LocalStorageTemplateServiceTest {
 
         // TODO verify actual contents of the profile.jfc?
         MatcherAssert.assertThat(
-                service.getEventsByTemplateName("Profiling").get().keySet(),
+                service.getEvents("Profiling", TemplateType.CUSTOM).get().keySet(),
                 Matchers.hasSize(Matchers.greaterThan(0)));
     }
 
     @Test
-    void getEventsByNameShouldThrowExceptionForUnknownName() throws Exception {
-        Assertions.assertFalse(service.getEventsByTemplateName("foo").isPresent());
+    void getEventsShouldReturnEmptyForUnknownName() throws Exception {
+        Assertions.assertFalse(service.getEvents("foo", TemplateType.CUSTOM).isPresent());
+    }
+
+    @Test
+    void getEventsShouldReturnEmptyForUnknownType() throws Exception {
+        Assertions.assertFalse(service.getEvents("foo", TemplateType.TARGET).isPresent());
     }
 
     @Test
@@ -161,7 +166,7 @@ class LocalStorageTemplateServiceTest {
         Mockito.when(fs.isReadable(path)).thenReturn(true);
 
         try {
-            Optional<Document> doc = service.getXml("Profiling");
+            Optional<Document> doc = service.getXml("Profiling", TemplateType.CUSTOM);
             Assertions.assertTrue(doc.isPresent());
             Assertions.assertTrue(
                     doc.get().hasSameValue(Jsoup.parse(xmlText, "", Parser.xmlParser())));
@@ -172,8 +177,13 @@ class LocalStorageTemplateServiceTest {
     }
 
     @Test
-    void getXmlShouldThrowExceptionForUnknownName() throws Exception {
-        Assertions.assertFalse(service.getXml("foo").isPresent());
+    void getXmlShouldReturnEmptyForUnknownName() throws Exception {
+        Assertions.assertFalse(service.getXml("foo", TemplateType.CUSTOM).isPresent());
+    }
+
+    @Test
+    void getXmlShouldReturnEmptyForUnknownType() throws Exception {
+        Assertions.assertFalse(service.getXml("foo", TemplateType.TARGET).isPresent());
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
@@ -107,7 +107,8 @@ class LocalStorageTemplateServiceTest {
                                 new Template(
                                         "Profiling",
                                         "Low overhead configuration for profiling, typically around 2 % overhead.",
-                                        "Oracle"))));
+                                        "Oracle",
+                                        TemplateType.CUSTOM))));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
@@ -165,15 +165,9 @@ class LocalStorageTemplateServiceTest {
         Mockito.when(fs.isDirectory(path)).thenReturn(true);
         Mockito.when(fs.isReadable(path)).thenReturn(true);
 
-        try {
-            Optional<Document> doc = service.getXml("Profiling", TemplateType.CUSTOM);
-            Assertions.assertTrue(doc.isPresent());
-            Assertions.assertTrue(
-                    doc.get().hasSameValue(Jsoup.parse(xmlText, "", Parser.xmlParser())));
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw e;
-        }
+        Optional<Document> doc = service.getXml("Profiling", TemplateType.CUSTOM);
+        Assertions.assertTrue(doc.isPresent());
+        Assertions.assertTrue(doc.get().hasSameValue(Jsoup.parse(xmlText, "", Parser.xmlParser())));
     }
 
     @Test
@@ -207,10 +201,10 @@ class LocalStorageTemplateServiceTest {
         Mockito.verify(fs).writeString(Mockito.eq(templatePath), contentCaptor.capture());
         String after = contentCaptor.getValue();
         int distance = LevenshteinDistance.getDefaultInstance().apply(xmlText, after);
-        // 4550 is just the experimentally determined LD. The XML is transformed somewhat when
+        // 1710 is just the experimentally determined LD. The XML is transformed somewhat when
         // parsed and re-serialized. Jsoup somehow determines that the document before and after
         // does not have the same value, but it clearly does from an actual inspection.
-        MatcherAssert.assertThat(distance, Matchers.is(4550));
+        MatcherAssert.assertThat(distance, Matchers.is(1710));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
@@ -202,4 +202,24 @@ class LocalStorageTemplateServiceTest {
         // does not have the same value, but it clearly does from an actual inspection.
         MatcherAssert.assertThat(distance, Matchers.is(4550));
     }
+
+    @Test
+    void deleteTemplateShouldDeleteFile() throws Exception {
+        Mockito.when(env.hasEnv(LocalStorageTemplateService.TEMPLATE_PATH)).thenReturn(true);
+        Mockito.when(env.getEnv(LocalStorageTemplateService.TEMPLATE_PATH))
+                .thenReturn("/templates");
+
+        Path path = Mockito.mock(Path.class);
+        Path templatePath = Mockito.mock(Path.class);
+        Mockito.when(fs.pathOf("/templates")).thenReturn(path);
+        Mockito.when(fs.exists(path)).thenReturn(true);
+        Mockito.when(fs.isDirectory(path)).thenReturn(true);
+        Mockito.when(fs.isReadable(path)).thenReturn(true);
+        Mockito.when(fs.isWritable(path)).thenReturn(true);
+        Mockito.when(fs.pathOf("/templates", "Profiling")).thenReturn(templatePath);
+
+        service.deleteTemplate("Profiling");
+
+        Mockito.verify(fs).deleteIfExists(templatePath);
+    }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
@@ -195,7 +195,6 @@ class LocalStorageTemplateServiceTest {
         ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
         Mockito.verify(fs).writeString(Mockito.eq(templatePath), contentCaptor.capture());
         String after = contentCaptor.getValue();
-        System.out.println(after);
         int distance = LevenshteinDistance.getDefaultInstance().apply(xmlText, after);
         // 4550 is just the experimentally determined LD. The XML is transformed somewhat when
         // parsed and re-serialized. Jsoup somehow determines that the document before and after

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
@@ -1,0 +1,175 @@
+/*-
+ * #%L
+ * Container JFR Core
+ * %%
+ * Copyright (C) 2020 Red Hat, Inc.
+ * %%
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * #L%
+ */
+package com.redhat.rhjmc.containerjfr.core.templates;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
+import com.redhat.rhjmc.containerjfr.core.sys.Environment;
+import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
+import com.redhat.rhjmc.containerjfr.core.templates.TemplateService.UnknownEventTemplateException;
+
+@ExtendWith(MockitoExtension.class)
+class LocalStorageTemplateServiceTest {
+
+    LocalStorageTemplateService service;
+    @Mock FileSystem fs;
+    @Mock Environment env;
+    String xmlText;
+
+    @BeforeEach
+    void setup() throws IOException {
+        xmlText = IOUtils.toString(this.getClass().getResourceAsStream("profile.jfc"));
+        this.service = new LocalStorageTemplateService(fs, env);
+    }
+
+    @Test
+    void getNamesShouldReflectLocalStorageTemplateNames() throws Exception {
+        Mockito.when(env.hasEnv(LocalStorageTemplateService.TEMPLATE_DIRECTORY)).thenReturn(true);
+        Mockito.when(env.getEnv(LocalStorageTemplateService.TEMPLATE_DIRECTORY))
+                .thenReturn("/templates");
+
+        Path path = Mockito.mock(Path.class);
+        Mockito.when(fs.pathOf("/templates")).thenReturn(path);
+        Mockito.when(fs.listDirectoryChildren(path)).thenReturn(List.of("profile.jfc"));
+
+        Path templatePath = Mockito.mock(Path.class);
+        Mockito.when(fs.pathOf("/templates", "profile.jfc")).thenReturn(templatePath);
+
+        InputStream stream = IOUtils.toInputStream(xmlText);
+        Mockito.when(fs.newInputStream(templatePath)).thenReturn(stream);
+
+        Mockito.when(fs.isDirectory(path)).thenReturn(true);
+        Mockito.when(fs.isReadable(path)).thenReturn(true);
+
+        MatcherAssert.assertThat(
+                service.getTemplates(),
+                Matchers.equalTo(
+                        Collections.singletonList(
+                                new Template(
+                                        "Profiling",
+                                        "Low overhead configuration for profiling, typically around 2 % overhead.",
+                                        "Oracle"))));
+    }
+
+    @Test
+    void getEventsByNameShouldReturnNonEmptyMap() throws Exception {
+        Mockito.when(env.hasEnv(LocalStorageTemplateService.TEMPLATE_DIRECTORY)).thenReturn(true);
+        Mockito.when(env.getEnv(LocalStorageTemplateService.TEMPLATE_DIRECTORY))
+                .thenReturn("/templates");
+
+        Path path = Mockito.mock(Path.class);
+        Mockito.when(fs.pathOf("/templates")).thenReturn(path);
+        Mockito.when(fs.listDirectoryChildren(path)).thenReturn(List.of("profile.jfc"));
+
+        Path templatePath = Mockito.mock(Path.class);
+        Mockito.when(fs.pathOf("/templates", "profile.jfc")).thenReturn(templatePath);
+
+        InputStream stream = IOUtils.toInputStream(xmlText);
+        Mockito.when(fs.newInputStream(templatePath)).thenReturn(stream);
+
+        Mockito.when(fs.isDirectory(path)).thenReturn(true);
+        Mockito.when(fs.isReadable(path)).thenReturn(true);
+
+        // TODO verify actual contents of the profile.jfc?
+        MatcherAssert.assertThat(
+                service.getEventsByTemplateName("Profiling").keySet(),
+                Matchers.hasSize(Matchers.greaterThan(0)));
+    }
+
+    @Test
+    void getEventsByNameShouldThrowExceptionForUnknownName() throws Exception {
+        Assertions.assertThrows(
+                FlightRecorderException.class, () -> service.getEventsByTemplateName("foo"));
+    }
+
+    @Test
+    void getXmlShouldReturnModelFromLocalStorage() throws Exception {
+        Mockito.when(env.hasEnv(LocalStorageTemplateService.TEMPLATE_DIRECTORY)).thenReturn(true);
+        Mockito.when(env.getEnv(LocalStorageTemplateService.TEMPLATE_DIRECTORY))
+                .thenReturn("/templates");
+
+        Path path = Mockito.mock(Path.class);
+        Mockito.when(fs.pathOf("/templates")).thenReturn(path);
+        Mockito.when(fs.listDirectoryChildren(path)).thenReturn(List.of("profile.jfc"));
+
+        Path templatePath = Mockito.mock(Path.class);
+        Mockito.when(fs.pathOf("/templates", "profile.jfc")).thenReturn(templatePath);
+
+        InputStream stream = IOUtils.toInputStream(xmlText);
+        Mockito.when(fs.newInputStream(templatePath)).thenReturn(stream);
+
+        Mockito.when(fs.isDirectory(path)).thenReturn(true);
+        Mockito.when(fs.isReadable(path)).thenReturn(true);
+
+        try {
+            Document doc = service.getXml("Profiling");
+            Assertions.assertTrue(doc.hasSameValue(Jsoup.parse(xmlText, "", Parser.xmlParser())));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    @Test
+    void getXmlShouldThrowExceptionForUnknownName() throws Exception {
+        Assertions.assertThrows(UnknownEventTemplateException.class, () -> service.getXml("foo"));
+    }
+}

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/LocalStorageTemplateServiceTest.java
@@ -217,6 +217,7 @@ class LocalStorageTemplateServiceTest {
         Mockito.when(fs.isReadable(path)).thenReturn(true);
         Mockito.when(fs.isWritable(path)).thenReturn(true);
         Mockito.when(fs.pathOf("/templates", "Profiling")).thenReturn(templatePath);
+        Mockito.when(fs.deleteIfExists(templatePath)).thenReturn(true);
 
         service.deleteTemplate("Profiling");
 

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/RemoteTemplateServiceTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/RemoteTemplateServiceTest.java
@@ -92,7 +92,8 @@ class RemoteTemplateServiceTest {
                                 new Template(
                                         "Profiling",
                                         "Low overhead configuration for profiling, typically around 2 % overhead.",
-                                        "Oracle"))));
+                                        "Oracle",
+                                        TemplateType.TARGET))));
     }
 
     @Test

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/RemoteTemplateServiceTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/RemoteTemplateServiceTest.java
@@ -76,15 +76,13 @@ class RemoteTemplateServiceTest {
     @BeforeEach
     void setup() throws Exception {
         xmlText = IOUtils.toString(this.getClass().getResourceAsStream("profile.jfc"));
-
-        Mockito.when(conn.getService()).thenReturn(svc);
-        Mockito.when(svc.getServerTemplates()).thenReturn(Collections.singletonList(xmlText));
-
         templateSvc = new RemoteTemplateService(conn);
     }
 
     @Test
     void getNamesShouldReflectRemoteTemplateNames() throws Exception {
+        Mockito.when(conn.getService()).thenReturn(svc);
+        Mockito.when(svc.getServerTemplates()).thenReturn(Collections.singletonList(xmlText));
         MatcherAssert.assertThat(
                 templateSvc.getTemplates(),
                 Matchers.equalTo(
@@ -97,7 +95,9 @@ class RemoteTemplateServiceTest {
     }
 
     @Test
-    void getEventsByNameShouldReturnNonEmptyMap() throws Exception {
+    void getEventsShouldReturnNonEmptyMap() throws Exception {
+        Mockito.when(conn.getService()).thenReturn(svc);
+        Mockito.when(svc.getServerTemplates()).thenReturn(Collections.singletonList(xmlText));
         Mockito.when(svc.getDefaultEventOptions())
                 .thenReturn(
                         new DefaultValueMap(
@@ -105,24 +105,40 @@ class RemoteTemplateServiceTest {
                                         EventTypeIDV2.class, Collections.emptyMap(), true)));
         // TODO verify actual contents of the profile.jfc?
         MatcherAssert.assertThat(
-                templateSvc.getEventsByTemplateName("Profiling").get().keySet(),
+                templateSvc.getEvents("Profiling", TemplateType.TARGET).get().keySet(),
                 Matchers.hasSize(Matchers.greaterThan(0)));
     }
 
     @Test
-    void getEventsByNameShouldThrowExceptionForUnknownName() throws Exception {
-        Assertions.assertFalse(templateSvc.getEventsByTemplateName("foo").isPresent());
+    void getEventsShouldReturnEmptyForUnknownName() throws Exception {
+        Mockito.when(conn.getService()).thenReturn(svc);
+        Mockito.when(svc.getServerTemplates()).thenReturn(Collections.singletonList(xmlText));
+        Assertions.assertFalse(templateSvc.getEvents("foo", TemplateType.TARGET).isPresent());
+    }
+
+    @Test
+    void getEventsShouldReturnEmptyForUnknownType() throws Exception {
+        Assertions.assertFalse(templateSvc.getEvents("foo", TemplateType.CUSTOM).isPresent());
     }
 
     @Test
     void getXmlShouldReturnModelFromRemote() throws Exception {
-        Optional<Document> doc = templateSvc.getXml("Profiling");
+        Mockito.when(conn.getService()).thenReturn(svc);
+        Mockito.when(svc.getServerTemplates()).thenReturn(Collections.singletonList(xmlText));
+        Optional<Document> doc = templateSvc.getXml("Profiling", TemplateType.TARGET);
         Assertions.assertTrue(doc.isPresent());
         Assertions.assertTrue(doc.get().hasSameValue(Jsoup.parse(xmlText, "", Parser.xmlParser())));
     }
 
     @Test
     void getXmlShouldReturnEmptyForUnknownName() throws Exception {
-        Assertions.assertFalse(templateSvc.getXml("foo").isPresent());
+        Mockito.when(conn.getService()).thenReturn(svc);
+        Mockito.when(svc.getServerTemplates()).thenReturn(Collections.singletonList(xmlText));
+        Assertions.assertFalse(templateSvc.getXml("foo", TemplateType.TARGET).isPresent());
+    }
+
+    @Test
+    void getXmlShouldReturnEmptyForUnknownType() throws Exception {
+        Assertions.assertFalse(templateSvc.getXml("foo", TemplateType.CUSTOM).isPresent());
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/RemoteTemplateServiceTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/RemoteTemplateServiceTest.java
@@ -46,6 +46,9 @@ import java.util.Collections;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -109,5 +112,16 @@ class RemoteTemplateServiceTest {
     void getEventsByNameShouldThrowExceptionForUnknownName() throws Exception {
         Assertions.assertThrows(
                 FlightRecorderException.class, () -> templateSvc.getEventsByTemplateName("foo"));
+    }
+
+    @Test
+    void getXmlShouldReturnModelFromRemote() throws Exception {
+        Document doc = templateSvc.getXml("Profiling");
+        Assertions.assertTrue(doc.hasSameValue(Jsoup.parse(xmlText, "", Parser.xmlParser())));
+    }
+
+    @Test
+    void getXmlShouldThrowExceptionForUnknownName() throws Exception {
+        Assertions.assertThrows(FlightRecorderException.class, () -> templateSvc.getXml("foo"));
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/RemoteTemplateServiceTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/templates/RemoteTemplateServiceTest.java
@@ -42,6 +42,7 @@
 package com.redhat.rhjmc.containerjfr.core.templates;
 
 import java.util.Collections;
+import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
@@ -62,7 +63,6 @@ import org.openjdk.jmc.flightrecorder.configuration.internal.EventOptionDescript
 import org.openjdk.jmc.flightrecorder.configuration.internal.EventTypeIDV2;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
-import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 
 @ExtendWith(MockitoExtension.class)
@@ -104,24 +104,24 @@ class RemoteTemplateServiceTest {
                                         EventTypeIDV2.class, Collections.emptyMap(), true)));
         // TODO verify actual contents of the profile.jfc?
         MatcherAssert.assertThat(
-                templateSvc.getEventsByTemplateName("Profiling").keySet(),
+                templateSvc.getEventsByTemplateName("Profiling").get().keySet(),
                 Matchers.hasSize(Matchers.greaterThan(0)));
     }
 
     @Test
     void getEventsByNameShouldThrowExceptionForUnknownName() throws Exception {
-        Assertions.assertThrows(
-                FlightRecorderException.class, () -> templateSvc.getEventsByTemplateName("foo"));
+        Assertions.assertFalse(templateSvc.getEventsByTemplateName("foo").isPresent());
     }
 
     @Test
     void getXmlShouldReturnModelFromRemote() throws Exception {
-        Document doc = templateSvc.getXml("Profiling");
-        Assertions.assertTrue(doc.hasSameValue(Jsoup.parse(xmlText, "", Parser.xmlParser())));
+        Optional<Document> doc = templateSvc.getXml("Profiling");
+        Assertions.assertTrue(doc.isPresent());
+        Assertions.assertTrue(doc.get().hasSameValue(Jsoup.parse(xmlText, "", Parser.xmlParser())));
     }
 
     @Test
-    void getXmlShouldThrowExceptionForUnknownName() throws Exception {
-        Assertions.assertThrows(FlightRecorderException.class, () -> templateSvc.getXml("foo"));
+    void getXmlShouldReturnEmptyForUnknownName() throws Exception {
+        Assertions.assertFalse(templateSvc.getXml("foo").isPresent());
     }
 }


### PR DESCRIPTION
See also: rh-jmc-team/container-jfr#199

This PR extends the Templates API to allow the raw template XMLs to be retrieved, and to allow custom template XMLs to be added, parsed, validated, and saved to the local filesystem. These custom templates can be retrieved on their own, or in a "merged" view alongside the built-in templates for a specific remote target.