### PR TITLE
Initial JMX authentication foundation

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/net/Credentials.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/net/Credentials.java
@@ -41,45 +41,28 @@
  */
 package com.redhat.rhjmc.containerjfr.core.net;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+public class Credentials {
 
-import javax.management.remote.JMXServiceURL;
+    private final String username;
+    private final String password;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import org.openjdk.jmc.rjmx.internal.WrappedConnectionException;
-
-import com.redhat.rhjmc.containerjfr.core.sys.Environment;
-import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
-import com.redhat.rhjmc.containerjfr.core.tui.ClientWriter;
-
-@ExtendWith(MockitoExtension.class)
-class JFRConnectionToolkitTest {
-
-    JFRConnectionToolkit toolkit;
-    @Mock ClientWriter cw;
-    @Mock FileSystem fs;
-    @Mock Environment env;
-
-    @BeforeEach
-    void setup() {
-        toolkit = new JFRConnectionToolkit(cw, fs, env);
+    public Credentials(String username, String password) {
+        this.username = username;
+        this.password = password;
     }
 
-    @ParameterizedTest
-    @ValueSource(
-            strings = {
-                "service:jmx:rmi:///jndi/rmi://container-jfr:9091/jmxrmi",
-                "service:jmx:rmi:///jndi/rmi://localhost/jmxrmi"
-            })
-    void shouldThrowInTestEnvironment(String s) {
-        assertThrows(
-                WrappedConnectionException.class,
-                () -> toolkit.connect(new JMXServiceURL(s)).connect());
+    String getUsername() {
+        return username;
+    }
+
+    String getPassword() {
+        return password;
+    }
+
+    @Override
+    public final String toString() {
+        // Don't override or modify this to include actual contents. This should be kept in-memory
+        // for as short a time as possible and never logged
+        return super.toString();
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnection.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnection.java
@@ -215,6 +215,7 @@ public class JFRConnection implements AutoCloseable {
             return conn;
         } catch (Exception e) {
             cw.println("connection attempt failed.");
+            closeListeners.forEach(Runnable::run);
             throw e;
         }
     }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnection.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnection.java
@@ -42,11 +42,13 @@
 package com.redhat.rhjmc.containerjfr.core.net;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.management.remote.JMXServiceURL;
 
+import org.openjdk.jmc.rjmx.ConnectionException;
 import org.openjdk.jmc.rjmx.ConnectionToolkit;
 import org.openjdk.jmc.rjmx.IConnectionDescriptor;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
@@ -72,9 +74,11 @@ public class JFRConnection implements AutoCloseable {
     protected final ClientWriter cw;
     protected final FileSystem fs;
     protected final Environment env;
-    protected final RJMXConnection rjmxConnection;
-    protected final IConnectionHandle handle;
-    protected final IFlightRecorderService service;
+    protected final FlightRecorderServiceFactory serviceFactory;
+    protected final List<Runnable> closeListeners;
+    protected RJMXConnection rjmxConnection;
+    protected IConnectionHandle handle;
+    protected IConnectionDescriptor connectionDescriptor;
 
     JFRConnection(
             ClientWriter cw,
@@ -86,12 +90,88 @@ public class JFRConnection implements AutoCloseable {
         this.cw = cw;
         this.fs = fs;
         this.env = env;
-        this.rjmxConnection = attemptConnect(cd);
+        this.connectionDescriptor = cd;
+        this.closeListeners = new ArrayList<>(listeners);
+        this.serviceFactory = new FlightRecorderServiceFactory();
+    }
+
+    JFRConnection(ClientWriter cw, FileSystem fs, Environment env, IConnectionDescriptor cd)
+            throws Exception {
+        this(cw, fs, env, cd, List.of());
+    }
+
+    public synchronized IConnectionHandle getHandle() {
+        return this.handle;
+    }
+
+    public synchronized IFlightRecorderService getService() throws Exception {
+        if (!isConnected()) {
+            connect();
+        }
+        IFlightRecorderService service = serviceFactory.getServiceInstance(handle);
+        if (service == null || !isConnected()) {
+            throw new ConnectionException(
+                    String.format(
+                            "Could not connect to remote target %s",
+                            this.connectionDescriptor.createJMXServiceURL().toString()));
+        }
+        return service;
+    }
+
+    public TemplateService getTemplateService() {
+        return new MergedTemplateService(this, fs, env);
+    }
+
+    public synchronized long getApproximateServerTime(Clock clock) {
+        return this.rjmxConnection.getApproximateServerTime(clock.getWallTime());
+    }
+
+    public synchronized JMXServiceURL getJMXURL() throws IOException {
+        return this.connectionDescriptor.createJMXServiceURL();
+    }
+
+    public synchronized String getHost() {
+        try {
+            return ConnectionToolkit.getHostName(
+                    this.rjmxConnection.getConnectionDescriptor().createJMXServiceURL());
+        } catch (IOException e) {
+            cw.println(e);
+            return "unknown";
+        }
+    }
+
+    public synchronized int getPort() {
+        try {
+            return ConnectionToolkit.getPort(
+                    this.rjmxConnection.getConnectionDescriptor().createJMXServiceURL());
+        } catch (IOException e) {
+            cw.println(e);
+            return 0;
+        }
+    }
+
+    public synchronized boolean isV1() {
+        return !isV2();
+    }
+
+    public synchronized boolean isV2() {
+        return FlightRecorderServiceV2.isAvailable(this.handle);
+    }
+
+    public synchronized boolean isConnected() {
+        return this.rjmxConnection != null && this.rjmxConnection.isConnected();
+    }
+
+    public synchronized void connect() throws Exception {
+        if (isConnected()) {
+            return;
+        }
+        this.rjmxConnection = attemptConnect(connectionDescriptor);
         this.handle =
                 new DefaultConnectionHandle(
                         rjmxConnection,
                         "RJMX Connection",
-                        listeners.stream()
+                        closeListeners.stream()
                                 .map(
                                         l ->
                                                 new IConnectionListener() {
@@ -103,78 +183,29 @@ public class JFRConnection implements AutoCloseable {
                                                 })
                                 .collect(Collectors.toList())
                                 .toArray(new IConnectionListener[0]));
-        this.service = new FlightRecorderServiceFactory().getServiceInstance(handle);
     }
 
-    JFRConnection(ClientWriter cw, FileSystem fs, Environment env, IConnectionDescriptor cd)
-            throws Exception {
-        this(cw, fs, env, cd, List.of());
-    }
-
-    public IConnectionHandle getHandle() {
-        return this.handle;
-    }
-
-    public IFlightRecorderService getService() {
-        return this.service;
-    }
-
-    public TemplateService getTemplateService() {
-        return new MergedTemplateService(this, fs, env);
-    }
-
-    public long getApproximateServerTime(Clock clock) {
-        return this.rjmxConnection.getApproximateServerTime(clock.getWallTime());
-    }
-
-    public JMXServiceURL getJMXURL() throws IOException {
-        return this.rjmxConnection.getConnectionDescriptor().createJMXServiceURL();
-    }
-
-    public String getHost() {
+    public synchronized void disconnect() {
         try {
-            return ConnectionToolkit.getHostName(
-                    this.rjmxConnection.getConnectionDescriptor().createJMXServiceURL());
-        } catch (IOException e) {
-            cw.println(e);
-            return "unknown";
-        }
-    }
-
-    public int getPort() {
-        try {
-            return ConnectionToolkit.getPort(
-                    this.rjmxConnection.getConnectionDescriptor().createJMXServiceURL());
-        } catch (IOException e) {
-            cw.println(e);
-            return 0;
-        }
-    }
-
-    public boolean isV1() {
-        return !isV2();
-    }
-
-    public boolean isV2() {
-        return FlightRecorderServiceV2.isAvailable(this.handle);
-    }
-
-    public void disconnect() {
-        try {
-            this.handle.close();
+            if (this.handle != null) {
+                this.handle.close();
+            }
         } catch (IOException e) {
             cw.println(e);
         } finally {
-            this.rjmxConnection.close();
+            if (this.rjmxConnection != null) {
+                this.rjmxConnection.close();
+            }
         }
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         this.disconnect();
     }
 
-    protected RJMXConnection attemptConnect(IConnectionDescriptor cd) throws Exception {
+    protected synchronized RJMXConnection attemptConnect(IConnectionDescriptor cd)
+            throws Exception {
         try {
             RJMXConnection conn =
                     new RJMXConnection(cd, new ServerDescriptor(), JFRConnection::failConnection);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkit.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkit.java
@@ -64,28 +64,23 @@ public class JFRConnectionToolkit {
     }
 
     public JFRConnection connect(JMXServiceURL url) throws Exception {
-        return connect(url, List.of());
+        return connect(url, null);
     }
 
-    public JFRConnection connect(JMXServiceURL url, List<Runnable> listeners) throws Exception {
-        return new JFRConnection(
-                cw, fs, env, new ConnectionDescriptorBuilder().url(url).build(), listeners);
+    public JFRConnection connect(JMXServiceURL url, Credentials credentials) throws Exception {
+        return connect(url, credentials, List.of());
     }
 
-    public JFRConnection connect(String host) throws Exception {
-        return connect(host, JFRConnection.DEFAULT_PORT);
-    }
-
-    public JFRConnection connect(String host, int port, List<Runnable> listeners) throws Exception {
-        return new JFRConnection(
-                cw,
-                fs,
-                env,
-                new ConnectionDescriptorBuilder().hostName(host).port(port).build(),
-                listeners);
-    }
-
-    public JFRConnection connect(String host, int port) throws Exception {
-        return connect(host, port, List.of());
+    public JFRConnection connect(
+            JMXServiceURL url, Credentials credentials, List<Runnable> listeners) throws Exception {
+        ConnectionDescriptorBuilder connectionDescriptorBuilder = new ConnectionDescriptorBuilder();
+        connectionDescriptorBuilder = connectionDescriptorBuilder.url(url);
+        if (credentials != null) {
+            connectionDescriptorBuilder =
+                    connectionDescriptorBuilder
+                            .username(credentials.getUsername())
+                            .password(credentials.getPassword());
+        }
+        return new JFRConnection(cw, fs, env, connectionDescriptorBuilder.build(), listeners);
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/AbstractTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/AbstractTemplateService.java
@@ -48,31 +48,25 @@ import java.util.stream.Collectors;
 import org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration.model.xml.XMLModel;
 import org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration.model.xml.XMLTagInstance;
 
-import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
-
 abstract class AbstractTemplateService implements TemplateService {
 
     @Override
-    public List<Template> getTemplates() throws FlightRecorderException {
-        try {
-            return getTemplateModels().stream()
-                    .map(xml -> xml.getRoot())
-                    .map(
-                            root ->
-                                    new Template(
-                                            getAttributeValue(root, "label"),
-                                            getAttributeValue(root, "description"),
-                                            getAttributeValue(root, "provider"),
-                                            providedTemplateType()))
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new FlightRecorderException(e);
-        }
+    public List<Template> getTemplates() throws Exception {
+        return getTemplateModels().stream()
+                .map(xml -> xml.getRoot())
+                .map(
+                        root ->
+                                new Template(
+                                        getAttributeValue(root, "label"),
+                                        getAttributeValue(root, "description"),
+                                        getAttributeValue(root, "provider"),
+                                        providedTemplateType()))
+                .collect(Collectors.toList());
     }
 
     protected abstract TemplateType providedTemplateType();
 
-    protected abstract List<XMLModel> getTemplateModels() throws FlightRecorderException;
+    protected abstract List<XMLModel> getTemplateModels() throws Exception;
 
     protected String getAttributeValue(XMLTagInstance node, String valueKey) {
         return node.getAttributeInstances().stream()

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/MergedTemplateService.java
@@ -52,7 +52,6 @@ import org.jsoup.nodes.Document;
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
 
-import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
 import com.redhat.rhjmc.containerjfr.core.net.JFRConnection;
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
@@ -68,7 +67,7 @@ public class MergedTemplateService implements MutableTemplateService {
     }
 
     @Override
-    public List<Template> getTemplates() throws FlightRecorderException {
+    public List<Template> getTemplates() throws Exception {
         List<Template> templates = new ArrayList<>();
         templates.addAll(remote.getTemplates());
         templates.addAll(local.getTemplates());
@@ -76,8 +75,7 @@ public class MergedTemplateService implements MutableTemplateService {
     }
 
     @Override
-    public Optional<Document> getXml(String templateName, TemplateType type)
-            throws FlightRecorderException {
+    public Optional<Document> getXml(String templateName, TemplateType type) throws Exception {
         switch (type) {
             case CUSTOM:
                 return local.getXml(templateName, type);
@@ -90,7 +88,7 @@ public class MergedTemplateService implements MutableTemplateService {
 
     @Override
     public Optional<IConstrainedMap<EventOptionID>> getEvents(
-            String templateName, TemplateType type) throws FlightRecorderException {
+            String templateName, TemplateType type) throws Exception {
         switch (type) {
             case CUSTOM:
                 return local.getEvents(templateName, type);

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/TemplateService.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/templates/TemplateService.java
@@ -49,15 +49,12 @@ import org.jsoup.nodes.Document;
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
 
-import com.redhat.rhjmc.containerjfr.core.FlightRecorderException;
-
 public interface TemplateService {
 
-    List<Template> getTemplates() throws FlightRecorderException;
+    List<Template> getTemplates() throws Exception;
 
-    Optional<Document> getXml(String templateName, TemplateType type)
-            throws FlightRecorderException;
+    Optional<Document> getXml(String templateName, TemplateType type) throws Exception;
 
     Optional<IConstrainedMap<EventOptionID>> getEvents(String templateName, TemplateType type)
-            throws FlightRecorderException;
+            throws Exception;
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/EventOptionsCustomizerTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/EventOptionsCustomizerTest.java
@@ -79,7 +79,7 @@ class EventOptionsCustomizerTest {
     EventOptionsCustomizer customizer;
 
     @BeforeEach
-    void setup() {
+    void setup() throws Exception {
         Mockito.when(connection.getService()).thenReturn(service);
         Mockito.when(service.getDefaultEventOptions()).thenReturn(defaultMap);
         Mockito.when(defaultMap.emptyWithSameConstraints()).thenReturn(emptyMap);

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkitTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkitTest.java
@@ -70,11 +70,12 @@ class JFRConnectionToolkitTest {
 
     @Test
     void shouldThrowInTestEnvironment() {
-        assertThrows(WrappedConnectionException.class, () -> toolkit.connect("foo", 9091));
+        assertThrows(
+                WrappedConnectionException.class, () -> toolkit.connect("foo", 9091).connect());
     }
 
     @Test
     void shouldThrowInTestEnvironment2() {
-        assertThrows(WrappedConnectionException.class, () -> toolkit.connect("foo"));
+        assertThrows(WrappedConnectionException.class, () -> toolkit.connect("foo").connect());
     }
 }


### PR DESCRIPTION
Related to rh-jmc-team/container-jfr#5

This causes JFRConnections to lazy-initialize, waiting until the consumer attempts to retrieve a Flight Recorder Service handle or other connection-required resource. When a connection attempt is made, optional JMX authentication credentials can be supplied to authenticate the request against the target's remote JMX access control. If these credentials are not supplied or are invalid, the connection attempt fails with an identifiable exception, allowing API consumers to implement ex. a mechanism for requesting credentials from the user, or at least notifying the user of the specific reason for the connection attempt failure.