### PR TITLE
Credentials implements equals/hashCode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>com.redhat.rhjmc</groupId>
 <artifactId>containerjfr-core</artifactId>
-<version>0.14.0</version>
+<version>0.14.1</version>
 <packaging>jar</packaging>
 <name>containerjfr-core</name>
 <url>http://maven.apache.org</url>

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/net/Credentials.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/net/Credentials.java
@@ -41,6 +41,9 @@
  */
 package com.redhat.rhjmc.containerjfr.core.net;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 public class Credentials {
 
     private final String username;
@@ -64,5 +67,28 @@ public class Credentials {
         // Don't override or modify this to include actual contents. This should be kept in-memory
         // for as short a time as possible and never logged
         return super.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof Credentials)) {
+            return false;
+        }
+        Credentials c = (Credentials) other;
+        return new EqualsBuilder()
+                .append(username, c.username)
+                .append(password, c.password)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(username).append(password).hashCode();
     }
 }


### PR DESCRIPTION
This allows Credentials and types which contain them (specifically, ContainerJFR's ConnectionDescriptor) to be used in Collection types like HashMaps. This is useful because a ConnectionDescriptor is a fairly natural caching key.