### PR TITLE
Add Functions from JMC's ConnectionToolkit

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkit.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkit.java
@@ -90,7 +90,7 @@ public class JFRConnectionToolkit {
         return ConnectionToolkit.getHostName(url);
     }
 
-    public static int getPort(JMXServiceURL url) {
+    public int getPort(JMXServiceURL url) {
         return ConnectionToolkit.getPort(url);
     }
 
@@ -98,7 +98,7 @@ public class JFRConnectionToolkit {
         return ConnectionToolkit.createServiceURL(host, port);
     }
 
-    public static int getDefaultPort() {
+    public int getDefaultPort() {
         return ConnectionToolkit.getDefaultPort();
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkit.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkit.java
@@ -41,11 +41,13 @@
  */
 package com.redhat.rhjmc.containerjfr.core.net;
 
+import java.net.MalformedURLException;
 import java.util.List;
 
 import javax.management.remote.JMXServiceURL;
 
 import org.openjdk.jmc.rjmx.ConnectionDescriptorBuilder;
+import org.openjdk.jmc.rjmx.ConnectionToolkit;
 
 import com.redhat.rhjmc.containerjfr.core.sys.Environment;
 import com.redhat.rhjmc.containerjfr.core.sys.FileSystem;
@@ -82,5 +84,21 @@ public class JFRConnectionToolkit {
                             .password(credentials.getPassword());
         }
         return new JFRConnection(cw, fs, env, connectionDescriptorBuilder.build(), listeners);
+    }
+
+    public String getHostName(JMXServiceURL url) {
+        return ConnectionToolkit.getHostName(url);
+    }
+
+    public static int getPort(JMXServiceURL url) {
+        return ConnectionToolkit.getPort(url);
+    }
+
+    public JMXServiceURL createServiceURL(String host, int port) throws MalformedURLException {
+        return ConnectionToolkit.createServiceURL(host, port);
+    }
+
+    public static int getDefaultPort() {
+        return ConnectionToolkit.getDefaultPort();
     }
 }

--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkit.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkit.java
@@ -41,9 +41,15 @@
  */
 package com.redhat.rhjmc.containerjfr.core.net;
 
+import java.io.IOException;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.lang.management.ThreadMXBean;
 import java.net.MalformedURLException;
 import java.util.List;
 
+import javax.management.MBeanServerConnection;
 import javax.management.remote.JMXServiceURL;
 
 import org.openjdk.jmc.rjmx.ConnectionDescriptorBuilder;
@@ -100,5 +106,22 @@ public class JFRConnectionToolkit {
 
     public int getDefaultPort() {
         return ConnectionToolkit.getDefaultPort();
+    }
+
+    public MemoryMXBean getMemoryBean(MBeanServerConnection server) throws IOException {
+        return ConnectionToolkit.getMemoryBean(server);
+    }
+
+    public RuntimeMXBean getRuntimeBean(MBeanServerConnection server) throws IOException {
+        return ConnectionToolkit.getRuntimeBean(server);
+    }
+
+    public ThreadMXBean getThreadBean(MBeanServerConnection server) throws IOException {
+        return ConnectionToolkit.getThreadBean(server);
+    }
+
+    public OperatingSystemMXBean getOperatingSystemBean(MBeanServerConnection server)
+            throws IOException {
+        return ConnectionToolkit.getOperatingSystemBean(server);
     }
 }

--- a/src/test/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkitTest.java
+++ b/src/test/java/com/redhat/rhjmc/containerjfr/core/net/JFRConnectionToolkitTest.java
@@ -41,11 +41,14 @@
  */
 package com.redhat.rhjmc.containerjfr.core.net;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.management.remote.JMXServiceURL;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -81,5 +84,29 @@ class JFRConnectionToolkitTest {
         assertThrows(
                 WrappedConnectionException.class,
                 () -> toolkit.connect(new JMXServiceURL(s)).connect());
+    }
+
+    @Test
+    void shouldGetHostName() throws Exception {
+        JMXServiceURL jmxServiceUrl = new JMXServiceURL("rmi", "localhost", 8080);
+        assertEquals(toolkit.getHostName(jmxServiceUrl), "localhost");
+    }
+
+    @Test
+    void shouldGetPort() throws Exception {
+        JMXServiceURL jmxServiceUrl = new JMXServiceURL("rmi", "localhost", 8080);
+        assertEquals(toolkit.getPort(jmxServiceUrl), 8080);
+    }
+
+    @Test
+    void shouldCreateServiceURL() throws Exception {
+        JMXServiceURL jmxServiceUrl =
+                new JMXServiceURL("rmi", "", 0, "/jndi/rmi://localhost:8080/jmxrmi");
+        assertTrue(toolkit.createServiceURL("localhost", 8080).equals(jmxServiceUrl));
+    }
+
+    @Test
+    void shouldGetDefaultPort() {
+        assertEquals(toolkit.getDefaultPort(), 7091);
     }
 }


### PR DESCRIPTION
Fixes #44.

These are the methods I didn't add. Would any of them be helpful to have?
```
public static ObjectName createObjectName(String name)
public static MemoryMXBean getMemoryBean(MBeanServerConnection server)
public static RuntimeMXBean getRuntimeBean(MBeanServerConnection server)
public static ThreadMXBean getThreadBean(MBeanServerConnection server)
public static OperatingSystemMXBean getOperatingSystemBean(MBeanServerConnection server)
public static Object invokeOperation(MBeanServerConnection server, ObjectName on, String operation, Object ... parameters)
public static boolean isJavaVersionAboveOrEqual(IConnectionHandle connectionHandle, JavaVersion minVersion)
