### PR TITLE
Avoid serializing credentials

### DIFF
--- a/src/main/java/com/redhat/rhjmc/containerjfr/core/net/Credentials.java
+++ b/src/main/java/com/redhat/rhjmc/containerjfr/core/net/Credentials.java
@@ -46,8 +46,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class Credentials {
 
-    private final String username;
-    private final String password;
+    private final transient String username;
+    private final transient String password;
 
     public Credentials(String username, String password) {
         this.username = username;


### PR DESCRIPTION
Mark credentials fields as transient to ensure serialization tools do not serialize the contents of Credentials objects.

https://sites.google.com/site/gson/gson-user-guide#TOC-Finer-Points-with-Objects