### PR TITLE
Add thin async JDP wrapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>com.redhat.rhjmc</groupId>
 <artifactId>containerjfr-core</artifactId>
-<version>0.16.0</version>
+<version>0.17.0</version>
 <packaging>jar</packaging>
 <name>containerjfr-core</name>
 <url>http://maven.apache.org</url>


### PR DESCRIPTION
Related to rh-jmc-team/container-jfr#158

This adds a thin wrapper around the existing JMC JDP async discovery listener mechanism, exposing it so ContainerJFR can listen asynchronously for changes to the set of known targets. These changes can then be written as Notifications (rh-jmc-team/container-jfr#330) and responded to by remote clients asynchronously, without client-side polling.