### PR TITLE
Use provided scope for spotbugs-annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>com.redhat.rhjmc</groupId>
 <artifactId>containerjfr-core</artifactId>
-<version>2.2.0</version>
+<version>2.2.1</version>
 <packaging>jar</packaging>
 <name>containerjfr-core</name>
 <url>http://maven.apache.org</url>
@@ -73,6 +73,7 @@
     <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs-annotations</artifactId>
     <version>${com.github.spotbugs.version}</version>
+    <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
We shouldn't need this included as a runtime dependency.