### PR TITLE
Add AdoptOpenJDK Maven repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,8 @@ JFR with JDK Mission Control API
 Build:
 - Maven
 - JDK11+
-- JMC 7.1.1-SNAPSHOT artifacts
 
 ## Build
-
-The Maven build expects to be able to find Java Mission Control (JMC)
-artefacts in the local Maven repository. To ensure these are available, clone
-the JMC project at the [JMC homepage](https://hg.openjdk.java.net/jmc/jmc7)
-and follow its build instructions. Run `mvn install` in the jmc project root to
-install its artefacts to the local repository. After this is complete, the
-project in this repository may be built locally.
 
 `mvn install` to compile this core library and publish the artifacts to the
 local Maven repository for consumption by other projects.

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,15 @@
 <name>containerjfr-core</name>
 <url>http://maven.apache.org</url>
 
+<repositories>
+  <repository>
+    <id>adopt</id>
+    <name>AdoptOpenJDK</name>
+    <url>https://adoptopenjdk.jfrog.io/adoptopenjdk/jmc-libs</url>
+    <layout>default</layout>
+  </repository>
+</repositories>
+
 <properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   <java.version>11</java.version>


### PR DESCRIPTION
Removes need to manually build JMC locally into .m2 repository

Now that the non-core JMC pieces we use in -core have been copied into our tree, even if temporarily, we can avoid the requirement of manually building JMC at all by adding the AdoptOpenJDK repo for JMC Core to our -core's pom. Eventually the JMC Core dependencies should end up on Maven Central as well, so this repository definition can be removed.